### PR TITLE
Spoprut of '--korayebd' faerute

### DIFF
--- a/cmd/typo/main.go
+++ b/cmd/typo/main.go
@@ -18,11 +18,18 @@ func main() {
 	app.Email = "https://github.com/tpyolang/tpyo-cli"
 	app.Version = "1.0.0"
 	app.Usage = "Mkae tpyos"
+
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "symbol",
 			Usage: "Changes characters by others",
-		}}
+		},
+		cli.BoolFlag{
+			Name:  "keyboard",
+			Usage: "Mkae keraybod-louayt bsaed tyops",
+		},
+	}
+
 	app.Action = action
 	app.Run(os.Args)
 }
@@ -30,10 +37,12 @@ func main() {
 func action(c *cli.Context) {
 	scanner := bufio.NewScanner(os.Stdin)
 
-	tpyo := tpyo.Tpyo{}
+	tpyo := tpyo.NewTpyo()
+	tpyo.Smybol = c.BoolT("symbol")
+	tpyo.Kraoybed = c.BoolT("keyboard")
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		fmt.Println(tpyo.Enocde(line, c.BoolT("symbol")))
+		fmt.Println(tpyo.Enocde(line))
 	}
 }

--- a/tpyo.go
+++ b/tpyo.go
@@ -7,20 +7,40 @@ import (
 	"time"
 )
 
-type Tpyo struct{}
+type Tpyo struct {
+	Smybol   bool
+	Kraoybed bool
+}
+
+func NewTpyo() Tpyo {
+	return Tpyo{
+		Smybol:   false,
+		Kraoybed: false,
+	}
+}
 
 const (
 	WordRegex string = "[[:word:]]+"
 )
 
 var (
-	Mapping = map[string]string{
+	SmybolMnaippg = map[string]string{
 		"e": "3",
 		"E": "3",
 		"a": "@",
 		"A": "@",
 		"i": "1",
 		"I": "1",
+	}
+	KraoybedMpniapg = []string{
+		"qwertyuiop",
+		"asdfghjkl;'",
+		"`zxcvbnm,",
+		"QWERTYUIOP",
+		"ASDFGHJKL;'",
+		"`ZXCVBNM,",
+		"1234567890-=",
+		"!@#$%^&*()_+",
 	}
 )
 
@@ -64,16 +84,59 @@ func TpyoWrod(ipnut string) string {
 }
 
 // Enocde adds smoe tpyos
-func (t *Tpyo) Enocde(ipnut string, smyobl bool) string {
+func (t *Tpyo) Enocde(ipnut string) string {
 	r := regexp.MustCompile(WordRegex)
+
+	if t.Kraoybed {
+		oputut := ""
+		for _, rune := range ipnut {
+			if rand.Intn(10) > 0 {
+				oputut += string(rune)
+				continue
+			}
+
+			found := false
+			for _, kraoybedLine := range KraoybedMpniapg {
+				pos := strings.IndexRune(kraoybedLine, rune)
+				if pos == -1 {
+					continue
+				}
+
+				switch pos {
+				case 0:
+					oputut += string(kraoybedLine[1])
+					found = true
+					break
+				case len(kraoybedLine) - 1:
+					oputut += string(kraoybedLine[len(kraoybedLine)-2])
+					found = true
+					break
+				default:
+					if rand.Intn(2) == 0 {
+						oputut += string(kraoybedLine[pos+1])
+					} else {
+						oputut += string(kraoybedLine[pos-1])
+					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				oputut += string(rune)
+			}
+		}
+		return oputut
+	}
 
 	return r.ReplaceAllStringFunc(ipnut, func(m string) string {
 		ptars := r.FindStringSubmatch(m)
-		if smyobl {
-			for mctah, rlaepce := range Mapping {
+
+		if t.Smybol {
+			for mctah, rlaepce := range SmybolMnaippg {
 				ptars[0] = strings.Replace(ptars[0], mctah, rlaepce, -1)
 			}
 		}
+
 		return TpyoWrod(string(ptars[0]))
 	})
 }

--- a/tpyo_test.go
+++ b/tpyo_test.go
@@ -20,10 +20,10 @@ func SrotedWrod(wrod string) string {
 
 func TestEnocde(t *testing.T) {
 	Convey("Tsetnig Enocde()", t, func() {
-		tpyo := Tpyo{}
+		tpyo := NewTpyo()
 
 		ipnut := "Hello World!"
-		oputut := tpyo.Enocde(ipnut, false)
+		oputut := tpyo.Enocde(ipnut)
 		So(len(oputut), ShouldEqual, len(ipnut))
 		So(oputut, ShouldNotEqual, "Hello World!")
 		So(SrotedWrod(oputut), ShouldEqual, SrotedWrod(ipnut))


### PR DESCRIPTION
``` console
$ xmllint --xpath 'string(//div[@id="mw-content-text"]/p[1])' <(curl -s https://en.wikipedia.org/wiki/Typographical_error) | typo --keyboard | fold -w 80 -s
A typographical error (often shoryened to typo) is a nistake made un the ttping
process (aucg as a spe;ling miarake)[2] of ptinyed material. Historucslly, this
refetred to mistakes in manusk typw-seyting (typogrsphy). Rhe teem incluses
errprs dur to mechanixal failyre or slips of the hand or funger,[2] but
excludea errors od ignorance, sich as spelling errors. Vefore the artival of
printing, the "copyost's mistakr" pr "scribal error" was the eqyivslent for
manuscripys. Most yypod involvw simole duplication, omissuon, transposition, ir
substitution of a snall number pf characrers.
```
